### PR TITLE
Ajout des campagnes vidéos Françaises

### DIFF
--- a/src/parts/campaigns.pug
+++ b/src/parts/campaigns.pug
@@ -30,15 +30,51 @@
       "nature",
       "health"
     ]
-  }; 
+  };      
 
 //- CAMPAIGNS
 -
   var campaigns =   [{
+    name : "Wilkinson",
+    tags : ["fr", "video", "man"],
+    id : "4401a015d21308a9bf301abf7011af15"
+  },{
+    name : "Tiffany & Co.",
+    tags : ["fr", "video", "jewelry"],
+    id : "1dc883509c0648cea876c675cbf57e63"
+  },{
+    name : "Hasbro",
+    tags : ["fr", "video", "child"],
+    id : "8cdfeaf4a9a0e5ed68ec6be8e6be658e"
+  },{
+    name : "Boiron",
+    tags : ["fr", "video", "health"],
+    id : "d87229a882a62e630bc68c763c98cc94"
+  },{
+    name : "Booking",
+    tags : ["fr", "video", "holidays"],
+    id : "a20bb26289b9331a59c9c97ba00719a0"
+  },{
+    name : "Royal Canin",
+    tags : ["fr", "video", "animal"],
+    id : "0de0e0df712e6b1b12517da79791c9a4"
+  },{
+    name : "Center Parcs",
+    tags : ["fr", "video", "nature"],
+    id : "6d3fcca4ec21fbf2a0e094ff88f4469d"
+  },{
+    name : "Amazon",
+    tags : ["fr", "video", "business"],
+    id : "de19ea005308fea7af8b0a19c99d28b8"
+  },{
+    name : "Samsung",
+    tags : ["fr", "video", "hightech"],
+    id : "23139ac3d58270955c33865fb359dbc1"
+  },{
     name : "Décathlon",
     tags : ["fr", "video", "sport"],
     id : "af419869e4f67647aed75848a23047ec"
-    },{
+  },{
     name : "Panzani",
     tags : ["fr", "video", "food"],
     id : "655108a49ba4170c40cc2234e19403d6"


### PR DESCRIPTION
Ajout de : 
*DEMO - Samsung ( Native Vidéo )
*DEMO -  Amazon ( Native Vidéo )
*DEMO -  Center Parcs ( Native Vidéo )
*DEMO -  Royal Canin ( Native Vidéo )
*DEMO -  Booking.com ( Native Vidéo )
*DEMO -  Boiron ( Native Vidéo ) 
*DEMO - Hasbro  ( Native Vidéo )
*DEMO -  Wilkinson ( Native Vidéo )
*DEMO -  Tiffany & Co. ( Native Vidéo ) 